### PR TITLE
split into 3 decorators

### DIFF
--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -47,7 +47,7 @@ def cached_class_method(timeout):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # skip the first qarg because it will be the class itself
+            # skip the first arg because it will be the class itself
             function_cache_key = utils. get_function_cache_key(func_name, args[1:], kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
@@ -79,7 +79,8 @@ def cached_instance_method(timeout):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            function_cache_key = utils. get_function_cache_key(func_name, args, kwargs)
+            # Need to include the first arg (self) in the cache key
+            function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
             try:

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -8,23 +8,78 @@ from django.core.cache import cache
 from django.utils.functional import wraps
 
 from cache_helper import utils
-from cache_helper.exceptions import CacheHelperFunctionError
-
 
 def cached(timeout):
 
     def _cached(func):
-        func_type = utils.get_function_type(func)
-        if func_type is None:
-            raise CacheHelperFunctionError('Error determining function type of {func}'.format(func=func))
-
         func_name = utils.get_function_name(func)
-        if func_name is None:
-            raise CacheHelperFunctionError('Error determining function name of {func}'.format(func=func))
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            function_cache_key = utils.get_function_cache_key(func_type, func_name, args, kwargs)
+            function_cache_key = utils. get_function_cache_key(func_name, args, kwargs)
+            cache_key = utils.get_hashed_cache_key(function_cache_key)
+
+            try:
+                value = cache.get(cache_key)
+            except Exception:
+                value = None
+
+            if value is None:
+                value = func(*args, **kwargs)
+                # Try and set the key, value pair in the cache.
+                # But if it fails on an error from the underlying
+                # cache system, handle it.
+                try:
+                    cache.set(cache_key, value, timeout)
+                except CacheSetError:
+                    pass
+
+            return value
+
+        return wrapper
+    return _cached
+
+
+def cached_class_method(timeout):
+
+    def _cached(func):
+        func_name = utils.get_function_name(func)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # skip the first qarg because it will be the class itself
+            function_cache_key = utils. get_function_cache_key(func_name, args[1:], kwargs)
+            cache_key = utils.get_hashed_cache_key(function_cache_key)
+
+            try:
+                value = cache.get(cache_key)
+            except Exception:
+                value = None
+
+            if value is None:
+                value = func(*args, **kwargs)
+                # Try and set the key, value pair in the cache.
+                # But if it fails on an error from the underlying
+                # cache system, handle it.
+                try:
+                    cache.set(cache_key, value, timeout)
+                except CacheSetError:
+                    pass
+
+            return value
+
+        return wrapper
+    return _cached
+
+
+def cached_instance_method(timeout):
+
+    def _cached(func):
+        func_name = utils.get_function_name(func)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            function_cache_key = utils. get_function_cache_key(func_name, args, kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
             try:

--- a/cache_helper/exceptions.py
+++ b/cache_helper/exceptions.py
@@ -4,7 +4,3 @@ class CacheHelperException(Exception):
 
 class CacheKeyCreationError(CacheHelperException):
     pass
-
-
-class CacheHelperFunctionError(CacheHelperException):
-    pass

--- a/cache_helper/utils.py
+++ b/cache_helper/utils.py
@@ -1,19 +1,12 @@
 from hashlib import sha256
-import inspect
 
 from cache_helper import settings
 from cache_helper.exceptions import CacheKeyCreationError
 from cache_helper.interfaces import CacheHelperCacheable
 
 
-def get_function_cache_key(func_type, func_name, func_args, func_kwargs):
-    if func_type in ['method', 'function']:
-        args_string = _sanitize_args(*func_args, **func_kwargs)
-    elif func_type == 'class_method':
-        # In this case, since we are dealing with a class method, the first arg to the function
-        # will be the class. Since the name of the class and function is already built in to the
-        # cache key, we can bypass the class variable and instead slice from the first index.
-        args_string = _sanitize_args(*func_args[1:], **func_kwargs)
+def get_function_cache_key(func_name, func_args, func_kwargs):
+    args_string = _sanitize_args(*func_args, **func_kwargs)
     key = '{func_name}{args_string}'.format(func_name=func_name, args_string=args_string)
     return key
 
@@ -38,30 +31,8 @@ def _sanitize_args(*args, **kwargs):
     return key.format(args_key=args_key, kwargs_key=kwargs_key)
 
 
-def get_function_type(func):
-    """
-    Gets the type of the given function
-    """
-    if 'self' in inspect.getfullargspec(func).args:
-        return 'method'
-    if 'cls' in inspect.getfullargspec(func).args:
-        return 'class_method'
-
-    if inspect.isfunction(func):
-        return 'function'
-
-    return None
-
-
 def get_function_name(func):
-    func_type = get_function_type(func)
-
-    if func_type in ['method', 'class_method', 'function']:
-        name = '{func_module}.{qualified_name}'\
-            .format(func_module=func.__module__, qualified_name=func.__qualname__)
-        return name
-
-    return None
+    return '{func_module}.{qualified_name}'.format(func_module=func.__module__, qualified_name=func.__qualname__)
 
 
 def _plumb_collections(input_item):

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -128,8 +128,6 @@ class CacheHelperTestBase(TestCase):
         Tests given key is in cache, making sure to get the hashed version of key first
         """
         finalized_key = get_hashed_cache_key(key)
-        print(key)
-        print(finalized_key)
         self.assertTrue(finalized_key in cache)
 
 

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -9,7 +9,7 @@ from cache_helper import settings
 from cache_helper.decorators import cached, cached_class_method, cached_instance_method
 from cache_helper.interfaces import CacheHelperCacheable
 from cache_helper.utils import get_hashed_cache_key, get_function_cache_key
-from cache_helper.exceptions import CacheKeyCreationError, CacheHelperFunctionError
+from cache_helper.exceptions import CacheKeyCreationError
 
 
 @cached(60*60)


### PR DESCRIPTION
[Pivotal TIcket](https://www.pivotaltracker.com/story/show/173047314)

## Overview
* Split @cached into 3 separate decorators
* Remove func_type logic and create cache key only from func_name and args / kwargs

## How to test
- [x] python setup.py install
- [x] python test_project/manage.py test test_project