### PR TITLE
Redo plumb collections

### DIFF
--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -36,7 +36,21 @@ def cached(timeout):
 
             return value
 
+        def invalidate(*args, **kwargs):
+            """
+            A method to invalidate a result from the cache.
+            :param args: The args passed into the original function. This includes `self` for instance methods, and
+            `cls` for class methods.
+            :param kwargs: The kwargs passed into the original function.
+            :rtype: None
+            """
+            function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
+            cache_key = utils.get_hashed_cache_key(function_cache_key)
+            cache.delete(cache_key)
+
+        wrapper.invalidate = invalidate
         return wrapper
+
     return _cached
 
 
@@ -49,6 +63,7 @@ def cached_class_method(timeout):
         def wrapper(*args, **kwargs):
             # skip the first qarg because it will be the class itself
             function_cache_key = utils. get_function_cache_key(func_name, args[1:], kwargs)
+            print(function_cache_key)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
             try:
@@ -68,7 +83,21 @@ def cached_class_method(timeout):
 
             return value
 
+        def invalidate(*args, **kwargs):
+            """
+            A method to invalidate a result from the cache.
+            :param args: The args passed into the original function. This includes `self` for instance methods, and
+            `cls` for class methods.
+            :param kwargs: The kwargs passed into the original function.
+            :rtype: None
+            """
+            function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
+            cache_key = utils.get_hashed_cache_key(function_cache_key)
+            cache.delete(cache_key)
+
+        wrapper.invalidate = invalidate
         return wrapper
+
     return _cached
 
 
@@ -76,9 +105,11 @@ def cached_instance_method(timeout):
 
     def _cached(func):
         func_name = utils.get_function_name(func)
+        print(func)
 
         @wraps(func)
         def wrapper(*args, **kwargs):
+            # print(func)
             function_cache_key = utils. get_function_cache_key(func_name, args, kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
@@ -100,4 +131,5 @@ def cached_instance_method(timeout):
             return value
 
         return wrapper
+
     return _cached

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -8,23 +8,78 @@ from django.core.cache import cache
 from django.utils.functional import wraps
 
 from cache_helper import utils
-from cache_helper.exceptions import CacheHelperFunctionError
-
 
 def cached(timeout):
 
     def _cached(func):
-        func_type = utils.get_function_type(func)
-        if func_type is None:
-            raise CacheHelperFunctionError('Error determining function type of {func}'.format(func=func))
-
         func_name = utils.get_function_name(func)
-        if func_name is None:
-            raise CacheHelperFunctionError('Error determining function name of {func}'.format(func=func))
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            function_cache_key = utils.get_function_cache_key(func_type, func_name, args, kwargs)
+            function_cache_key = utils. get_function_cache_key(func_name, args, kwargs)
+            cache_key = utils.get_hashed_cache_key(function_cache_key)
+
+            try:
+                value = cache.get(cache_key)
+            except Exception:
+                value = None
+
+            if value is None:
+                value = func(*args, **kwargs)
+                # Try and set the key, value pair in the cache.
+                # But if it fails on an error from the underlying
+                # cache system, handle it.
+                try:
+                    cache.set(cache_key, value, timeout)
+                except CacheSetError:
+                    pass
+
+            return value
+
+        return wrapper
+    return _cached
+
+
+def cached_class_method(timeout):
+
+    def _cached(func):
+        func_name = utils.get_function_name(func)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # skip the first qarg because it will be the class itself
+            function_cache_key = utils. get_function_cache_key(func_name, args[1:], kwargs)
+            cache_key = utils.get_hashed_cache_key(function_cache_key)
+
+            try:
+                value = cache.get(cache_key)
+            except Exception:
+                value = None
+
+            if value is None:
+                value = func(*args, **kwargs)
+                # Try and set the key, value pair in the cache.
+                # But if it fails on an error from the underlying
+                # cache system, handle it.
+                try:
+                    cache.set(cache_key, value, timeout)
+                except CacheSetError:
+                    pass
+
+            return value
+
+        return wrapper
+    return _cached
+
+
+def cached_instance_method(timeout):
+
+    def _cached(func):
+        func_name = utils.get_function_name(func)
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            function_cache_key = utils. get_function_cache_key(func_name, args, kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
             try:

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     from cache_helper.exceptions import CacheHelperException as CacheSetError
 
+import functools
 
 from django.core.cache import cache
 from django.utils.functional import wraps
@@ -63,7 +64,6 @@ def cached_class_method(timeout):
         def wrapper(*args, **kwargs):
             # skip the first qarg because it will be the class itself
             function_cache_key = utils. get_function_cache_key(func_name, args[1:], kwargs)
-            print(function_cache_key)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
             try:
@@ -102,24 +102,24 @@ def cached_class_method(timeout):
 
 
 def cached_instance_method(timeout):
+    class wrapper:
+        def __init__(self, func):
+            self.func = func
 
-    def _cached(func):
-        func_name = utils.get_function_name(func)
-        print(func)
+        def __get__(self, obj, objtype):
+            fn = functools.partial(self.__call__, obj)
+            fn.invalidate = functools.partial(self.invalidate, obj)
 
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            # print(func)
-            function_cache_key = utils. get_function_cache_key(func_name, args, kwargs)
-            cache_key = utils.get_hashed_cache_key(function_cache_key)
+            return fn
 
+        def __call__(self, *args, **kwargs):
+            cache_key = self.create_cache_key(*args, **kwargs)
             try:
                 value = cache.get(cache_key)
             except Exception:
                 value = None
-
             if value is None:
-                value = func(*args, **kwargs)
+                value = self.func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
                 # cache system, handle it.
@@ -127,9 +127,23 @@ def cached_instance_method(timeout):
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     pass
-
             return value
 
-        return wrapper
+        def invalidate(self, *args, **kwargs):
+            """
+            A method to invalidate a result from the cache.
+            :param args: The args passed into the original function. This includes `self` for instance methods, and
+            `cls` for class methods.
+            :param kwargs: The kwargs passed into the original function.
+            :rtype: None
+            """
+            cache_key = self.create_cache_key(*args, **kwargs)
+            cache.delete(cache_key)
 
-    return _cached
+        def create_cache_key(self, *args, **kwargs):
+            func_name = utils.get_function_name(self.func)
+            function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
+            cache_key = utils.get_hashed_cache_key(function_cache_key)
+            return cache_key
+
+    return wrapper

--- a/cache_helper/utils.py
+++ b/cache_helper/utils.py
@@ -1,19 +1,12 @@
 from hashlib import sha256
-import inspect
 
 from cache_helper import settings
 from cache_helper.exceptions import CacheKeyCreationError
 from cache_helper.interfaces import CacheHelperCacheable
 
 
-def get_function_cache_key(func_type, func_name, func_args, func_kwargs):
-    if func_type in ['method', 'function']:
-        args_string = _sanitize_args(*func_args, **func_kwargs)
-    elif func_type == 'class_method':
-        # In this case, since we are dealing with a class method, the first arg to the function
-        # will be the class. Since the name of the class and function is already built in to the
-        # cache key, we can bypass the class variable and instead slice from the first index.
-        args_string = _sanitize_args(*func_args[1:], **func_kwargs)
+def get_function_cache_key(func_name, func_args, func_kwargs):
+    args_string = _sanitize_args(*func_args, **func_kwargs)
     key = '{func_name}{args_string}'.format(func_name=func_name, args_string=args_string)
     return key
 
@@ -38,30 +31,8 @@ def _sanitize_args(*args, **kwargs):
     return key.format(args_key=args_key, kwargs_key=kwargs_key)
 
 
-def get_function_type(func):
-    """
-    Gets the type of the given function
-    """
-    if 'self' in inspect.getfullargspec(func).args:
-        return 'method'
-    if 'cls' in inspect.getfullargspec(func).args:
-        return 'class_method'
-
-    if inspect.isfunction(func):
-        return 'function'
-
-    return None
-
-
 def get_function_name(func):
-    func_type = get_function_type(func)
-
-    if func_type in ['method', 'class_method', 'function']:
-        name = '{func_module}.{qualified_name}'\
-            .format(func_module=func.__module__, qualified_name=func.__qualname__)
-        return name
-
-    return None
+    return '{func_module}.{qualified_name}'.format(func_module=func.__module__, qualified_name=func.__qualname__)
 
 
 def _plumb_collections(input_item):

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -383,21 +383,21 @@ class CacheableTestCase(CacheHelperTestBase):
 
 
 class CacheInvalidateTestCase(CacheHelperTestBase):
-    # def test_invalidate_instance_method(self):
-    #     """
-    #     Tests that invalidate works on an instance method
-    #     """
-    #     expected_apple_cache_key = 'test_project.tests.Fruit.fun_math;MyNameIsApple,1,1;'
-    #
-    #     self.assertKeyNotInCache(expected_apple_cache_key)
-    #
-    #     # Call the function, store result in the cache
-    #     self.apple.fun_math(1, 1)
-    #     self.assertExpectedKeyInCache(expected_apple_cache_key)
-    #
-    #     # Invalidate the call, now the result is no longer in the cache
-    #     self.apple.fun_math.invalidate(self.apple, 1, 1)
-    #     self.assertKeyNotInCache(expected_apple_cache_key)
+    def test_invalidate_instance_method(self):
+        """
+        Tests that invalidate works on an instance method
+        """
+        expected_apple_cache_key = 'test_project.tests.Fruit.fun_math;MyNameIsApple,1,1;'
+
+        self.assertKeyNotInCache(expected_apple_cache_key)
+
+        # Call the function, store result in the cache
+        self.apple.fun_math(1, 1)
+        self.assertExpectedKeyInCache(expected_apple_cache_key)
+
+        # Invalidate the call, now the result is no longer in the cache
+        self.apple.fun_math.invalidate(1, 1)
+        self.assertKeyNotInCache(expected_apple_cache_key)
 
     def test_invalidate_static_method(self):
         """
@@ -432,6 +432,9 @@ class CacheInvalidateTestCase(CacheHelperTestBase):
         self.assertKeyNotInCache(expected_apple_cache_key)
 
     def test_invalidate_only_removes_one_key(self):
+        """
+        Tests that calling invalidate only removes a single key, and does not disturb other similar keys in the cache.
+        """
         self.apple.fun_math(7, 15)
         self.apple.fun_math(7, 16)
         self.apple.fun_math(15, 7)
@@ -447,7 +450,7 @@ class CacheInvalidateTestCase(CacheHelperTestBase):
         for key in expected_cache_keys:
             self.assertExpectedKeyInCache(key)
 
-        self.apple.fun_math.invalidate(self.apple, 7, 15)
+        self.apple.fun_math.invalidate(7, 15)
 
         self.assertKeyNotInCache(expected_cache_keys[0])
         for key in expected_cache_keys[1:]:


### PR DESCRIPTION
[Pivotal Ticket](https://www.pivotaltracker.com/story/show/172972286)

### Overview
Simplify the way we create cache keys by only checking the top level args and kwargs to check for get_cache_helper_key()

Redo the entire test suite to test functionality rather than implementation