### PR TITLE
Create new DFS strategy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,19 +17,9 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [ 3.4, 3.5, 3.6, 3.7 ]
+        python-version: [ 3.6, 3.7 ]
         django-version: [ 1.7.*, 1.8.*, 1.9.*, 1.10.*, 1.11.*, 2.0.*, 2.1.*, 2.2.*, 3.0.* ]
         exclude:
-          - python-version: 3.4
-            django-version: 2.1.*
-          - python-version: 3.4
-            django-version: 2.2.*
-          - python-version: 3.4
-            django-version: 3.0.*
-          - python-version: 3.5
-            django-version: 1.7.*
-          - python-version: 3.5
-            django-version: 3.0.*
           - python-version: 3.6
             django-version: 1.7.*
           - python-version: 3.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,19 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7 ]
+        python-version: [ 3.4, 3.5, 3.6, 3.7 ]
         django-version: [ 1.7.*, 1.8.*, 1.9.*, 1.10.*, 1.11.*, 2.0.*, 2.1.*, 2.2.*, 3.0.* ]
         exclude:
+          - python-version: 3.4
+            django-version: 2.1.*
+          - python-version: 3.4
+            django-version: 2.2.*
+          - python-version: 3.4
+            django-version: 3.0.*
+          - python-version: 3.5
+            django-version: 1.7.*
+          - python-version: 3.5
+            django-version: 3.0.*
           - python-version: 3.6
             django-version: 1.7.*
           - python-version: 3.7

--- a/cache_helper/exceptions.py
+++ b/cache_helper/exceptions.py
@@ -1,2 +1,5 @@
 class CacheHelperException(Exception):
     pass
+
+class CacheKeyCreationError(CacheHelperException):
+    pass

--- a/cache_helper/settings.py
+++ b/cache_helper/settings.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+MAX_DEPTH = getattr(settings, 'CACHE_HELPER_MAX_DEPTH', 10)

--- a/cache_helper/utils.py
+++ b/cache_helper/utils.py
@@ -61,7 +61,7 @@ def build_cache_key_using_dfs(input_item):
     def _get_deterministic_iterable(iterable, _depth):
         """
         Helper function for the DFS that takes an iterable and sorts it deterministically. This is necessary so that
-        equivalent dicts / sets are guaranteed to be cached using the same key
+        equivalent dicts / sets are guaranteed to be mapped to the same cache key
 
         :param iterable: The input iterable, potentially unordered
         :param _depth: The current depth of the DFS
@@ -85,7 +85,8 @@ def build_cache_key_using_dfs(input_item):
         return deterministic_iterable
 
     return_string = ''
-    stack = [item for item in _get_deterministic_iterable(input_item, 0)]
+    # Start the depth at -1 because args come in as a tuple and kwargs come in as a dict
+    stack = [item for item in _get_deterministic_iterable(input_item, -1)]
 
     while stack:
         current_item, depth = stack.pop()
@@ -97,6 +98,6 @@ def build_cache_key_using_dfs(input_item):
             return_string += ','
             stack.extend(_get_deterministic_iterable(current_item, depth))
         else:
-            return_string += f'_get_object_cache_key(current_item)'
+            return_string += f'{_get_object_cache_key(current_item)},'
 
     return return_string

--- a/cache_helper/utils.py
+++ b/cache_helper/utils.py
@@ -31,7 +31,7 @@ def build_args_string(*args, **kwargs):
     args_key = build_cache_key_using_dfs(args)
     kwargs_key = build_cache_key_using_dfs(kwargs)
 
-    return f';{args_key};{kwargs_key}'
+    return ';{args_key};{kwargs_key}'.format(args_key=args_key, kwargs_key=kwargs_key)
 
 def get_function_name(func):
     return '{func_module}.{qualified_name}'.format(func_module=func.__module__, qualified_name=func.__qualname__)
@@ -62,14 +62,14 @@ def build_cache_key_using_dfs(input_item):
     while stack:
         current_item, depth = stack.pop()
         if settings.MAX_DEPTH is not None and depth > settings.MAX_DEPTH:
-            raise CacheKeyCreationError(f'Function args / kwargs have too many nested collections'
-                                        f' for MAX_DEPTH {settings.MAX_DEPTH}')
+            raise CacheKeyCreationError('Function args / kwargs have too many nested collections'
+                                        ' for MAX_DEPTH {max_depth}'.format(max_depth=settings.MAX_DEPTH))
 
         if hasattr(current_item, '__iter__') and not isinstance(current_item, str):
             return_string += ','
             stack.extend(_get_deterministic_iterable(current_item, depth))
         else:
-            return_string += f'{_get_object_cache_key(current_item)},'
+            return_string += '{},'.format(_get_object_cache_key(current_item))
 
     return return_string
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-cache-helper',
-    version='1.0.0',
+    version='1.1.0',
     description='Helps cache stuff',
     author='YCharts',
     author_email='operator@ycharts.com',

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -541,3 +541,175 @@ class CacheHelperCacheableTests(TestCase):
         initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(0, 'a', kwarg_1=obj_1, kwarg_2='hmm')
         initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(0, 'a', kwarg_2='hmm', kwarg_1=obj_1)
         self.assertEqual(initial_datetime_1, initial_datetime_2)
+
+    def test_list_of_cacheable_args(self):
+        """
+        Tests that an arg containing a list of CacheHelperCacheables will cache properly.
+        """
+        obj_1 = CacheableIfSumsAreEqual(1, 3)  # sum = 4
+        obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
+        obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
+
+        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs([obj_1, obj_2, obj_3], None)
+        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs([obj_3, obj_2, obj_1], None)
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+
+        # Test that order matters
+        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs([obj_2, obj_1, obj_3], None)
+        self.assertNotEqual(initial_datetime_1, initial_datetime_3)
+
+        # Test that num elements matters
+        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs([obj_2, obj_1], None)
+        self.assertNotEqual(initial_datetime_1, initial_datetime_4)
+
+    def test_tuple_of_cacheable_args(self):
+        """
+        Tests that an arg containing a tuple of CacheHelperCacheables will cache properly.
+        """
+        obj_1 = CacheableIfSumsAreEqual(1, 3)  # sum = 4
+        obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
+        obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
+
+        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs((obj_1, obj_2, obj_3), None)
+        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs((obj_3, obj_2, obj_1), None)
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+
+        # Test that order matters
+        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs((obj_2, obj_1, obj_3), None)
+        self.assertNotEqual(initial_datetime_1, initial_datetime_3)
+
+        # Test that num elements matters
+        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs((obj_2, obj_1), None)
+        self.assertNotEqual(initial_datetime_1, initial_datetime_4)
+
+    def test_set_of_cacheable_args(self):
+        """
+        Tests that an arg containing a set of CacheHelperCacheables will cache properly.
+        """
+        obj_1 = CacheableIfSumsAreEqual(1, 3)  # sum = 4
+        obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
+        obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
+
+        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs({obj_1, obj_2}, None)
+        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs({obj_2, obj_1}, None)
+        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs({obj_2, obj_3}, None)
+        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs({obj_3, obj_2}, None)
+
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+        self.assertEqual(initial_datetime_1, initial_datetime_3)
+        self.assertEqual(initial_datetime_1, initial_datetime_4)
+
+        # Test that num elements matters
+        initial_datetime_5 = Incrementer.func_with_multiple_args_and_kwargs({obj_2, obj_1, obj_3}, None)
+        self.assertNotEqual(initial_datetime_1, initial_datetime_5)
+
+    def test_dict_of_cacheable_args(self):
+        """
+        Tests that an arg containing a dict of CacheHelperCacheables will cache properly.
+        """
+        obj_1 = CacheableIfSumsAreEqual(1, 3)  # sum = 4
+        obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
+        obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
+
+        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs({1: obj_1, 2: obj_2}, None)
+        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs({2: obj_2, 1: obj_1}, None)
+        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs({2: obj_2, 1: obj_3}, None)
+        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs({1: obj_3, 2: obj_2}, None)
+
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+        self.assertEqual(initial_datetime_1, initial_datetime_3)
+        self.assertEqual(initial_datetime_1, initial_datetime_4)
+
+        # Test that num elements matters
+        initial_datetime_5 = Incrementer.func_with_multiple_args_and_kwargs({1: obj_3, 2: obj_2, 3: obj_1}, None)
+        self.assertNotEqual(initial_datetime_1, initial_datetime_5)
+
+    def test_list_of_cacheable_kwargs(self):
+        """
+        Tests that a kwarg containing a list of CacheHelperCacheables will cache properly.
+        """
+        obj_1 = CacheableIfSumsAreEqual(1, 3)  # sum = 4
+        obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
+        obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
+
+        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=[obj_1, obj_2, obj_3])
+        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=[obj_3, obj_2, obj_1])
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+
+        # Test that order matters
+        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=[obj_2, obj_1, obj_3])
+        self.assertNotEqual(initial_datetime_1, initial_datetime_3)
+
+        # Test that num elements matters
+        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=[obj_2, obj_1])
+        self.assertNotEqual(initial_datetime_1, initial_datetime_4)
+
+    def test_tuple_of_cacheable_kwargs(self):
+        """
+        Tests that a kwarg containing a tuple of CacheHelperCacheables will cache properly.
+        """
+        obj_1 = CacheableIfSumsAreEqual(1, 3)  # sum = 4
+        obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
+        obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
+
+        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=(obj_1, obj_2, obj_3))
+        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=(obj_3, obj_2, obj_1))
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+
+        # Test that order matters
+        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=(obj_2, obj_1, obj_3))
+        self.assertNotEqual(initial_datetime_1, initial_datetime_3)
+
+        # Test that num elements matters
+        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=(obj_2, obj_1))
+        self.assertNotEqual(initial_datetime_1, initial_datetime_4)
+
+    def test_set_of_cacheable_kwargs(self):
+        """
+        Tests that a kwarg containing a set of CacheHelperCacheables will cache properly.
+        """
+        obj_1 = CacheableIfSumsAreEqual(1, 3)  # sum = 4
+        obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
+        obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
+
+        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_1, obj_2})
+        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_2, obj_1})
+        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_2, obj_3})
+        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_3, obj_2})
+
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+        self.assertEqual(initial_datetime_1, initial_datetime_3)
+        self.assertEqual(initial_datetime_1, initial_datetime_4)
+
+        # Test that num elements matters
+        initial_datetime_5 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_2, obj_1, obj_3})
+        self.assertNotEqual(initial_datetime_1, initial_datetime_5)
+
+    def test_dict_of_cacheable_kwargs(self):
+        """
+        Tests that a kwarg containing a dict of CacheHelperCacheables will cache properly.
+        """
+        obj_1 = CacheableIfSumsAreEqual(1, 3)  # sum = 4
+        obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
+        obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
+
+        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={1: obj_1, 2: obj_2})
+        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={2: obj_2, 1: obj_1})
+        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={2: obj_2, 1: obj_3})
+        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={1: obj_3, 2: obj_2})
+
+        self.assertEqual(initial_datetime_1, initial_datetime_2)
+        self.assertEqual(initial_datetime_1, initial_datetime_3)
+        self.assertEqual(initial_datetime_1, initial_datetime_4)
+
+        # Test that num elements matters
+        initial_datetime_5 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={1: obj_3, 2: obj_2, 3: obj_1})
+        self.assertNotEqual(initial_datetime_1, initial_datetime_5)
+
+    def test_max_depth(self):
+        pass
+
+    def test_complex_example(self):
+        pass

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -712,6 +712,10 @@ class CacheHelperCacheableTests(TestCase):
 
 class MaxDepthTests(TestCase):
 
+    def tearDown(self):
+        super().tearDown()
+        cache.clear()
+
     @patch('cache_helper.settings.MAX_DEPTH', 2)
     def test_max_depth_on_list_args_success(self):
         """

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -1,9 +1,10 @@
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.core.cache import cache
 
 from cache_helper.decorators import cached, cached_class_method, cached_instance_method
+from cache_helper.exceptions import CacheKeyCreationError
 from cache_helper.interfaces import CacheHelperCacheable
 
 from datetime import datetime
@@ -550,16 +551,16 @@ class CacheHelperCacheableTests(TestCase):
         obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
         obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
 
-        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs([obj_1, obj_2, obj_3], None)
-        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs([obj_3, obj_2, obj_1], None)
+        initial_datetime_1 = Incrementer.get_datetime([obj_1, obj_2, obj_3])
+        initial_datetime_2 = Incrementer.get_datetime([obj_3, obj_2, obj_1])
         self.assertEqual(initial_datetime_1, initial_datetime_2)
 
         # Test that order matters
-        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs([obj_2, obj_1, obj_3], None)
+        initial_datetime_3 = Incrementer.get_datetime([obj_2, obj_1, obj_3])
         self.assertNotEqual(initial_datetime_1, initial_datetime_3)
 
         # Test that num elements matters
-        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs([obj_2, obj_1], None)
+        initial_datetime_4 = Incrementer.get_datetime([obj_2, obj_1])
         self.assertNotEqual(initial_datetime_1, initial_datetime_4)
 
     def test_tuple_of_cacheable_args(self):
@@ -570,17 +571,17 @@ class CacheHelperCacheableTests(TestCase):
         obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
         obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
 
-        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs((obj_1, obj_2, obj_3), None)
-        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs((obj_3, obj_2, obj_1), None)
+        initial_datetime_1 = Incrementer.get_datetime((obj_1, obj_2, obj_3))
+        initial_datetime_2 = Incrementer.get_datetime((obj_3, obj_2, obj_1))
         self.assertEqual(initial_datetime_1, initial_datetime_2)
         self.assertEqual(initial_datetime_1, initial_datetime_2)
 
         # Test that order matters
-        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs((obj_2, obj_1, obj_3), None)
+        initial_datetime_3 = Incrementer.get_datetime((obj_2, obj_1, obj_3))
         self.assertNotEqual(initial_datetime_1, initial_datetime_3)
 
         # Test that num elements matters
-        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs((obj_2, obj_1), None)
+        initial_datetime_4 = Incrementer.get_datetime((obj_2, obj_1))
         self.assertNotEqual(initial_datetime_1, initial_datetime_4)
 
     def test_set_of_cacheable_args(self):
@@ -591,17 +592,17 @@ class CacheHelperCacheableTests(TestCase):
         obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
         obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
 
-        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs({obj_1, obj_2}, None)
-        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs({obj_2, obj_1}, None)
-        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs({obj_2, obj_3}, None)
-        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs({obj_3, obj_2}, None)
+        initial_datetime_1 = Incrementer.get_datetime({obj_1, obj_2})
+        initial_datetime_2 = Incrementer.get_datetime({obj_2, obj_1})
+        initial_datetime_3 = Incrementer.get_datetime({obj_2, obj_3})
+        initial_datetime_4 = Incrementer.get_datetime({obj_3, obj_2})
 
         self.assertEqual(initial_datetime_1, initial_datetime_2)
         self.assertEqual(initial_datetime_1, initial_datetime_3)
         self.assertEqual(initial_datetime_1, initial_datetime_4)
 
         # Test that num elements matters
-        initial_datetime_5 = Incrementer.func_with_multiple_args_and_kwargs({obj_2, obj_1, obj_3}, None)
+        initial_datetime_5 = Incrementer.get_datetime({obj_2, obj_1, obj_3})
         self.assertNotEqual(initial_datetime_1, initial_datetime_5)
 
     def test_dict_of_cacheable_args(self):
@@ -612,17 +613,17 @@ class CacheHelperCacheableTests(TestCase):
         obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
         obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
 
-        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs({1: obj_1, 2: obj_2}, None)
-        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs({2: obj_2, 1: obj_1}, None)
-        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs({2: obj_2, 1: obj_3}, None)
-        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs({1: obj_3, 2: obj_2}, None)
+        initial_datetime_1 = Incrementer.get_datetime({1: obj_1, 2: obj_2})
+        initial_datetime_2 = Incrementer.get_datetime({2: obj_2, 1: obj_1})
+        initial_datetime_3 = Incrementer.get_datetime({2: obj_2, 1: obj_3})
+        initial_datetime_4 = Incrementer.get_datetime({1: obj_3, 2: obj_2})
 
         self.assertEqual(initial_datetime_1, initial_datetime_2)
         self.assertEqual(initial_datetime_1, initial_datetime_3)
         self.assertEqual(initial_datetime_1, initial_datetime_4)
 
         # Test that num elements matters
-        initial_datetime_5 = Incrementer.func_with_multiple_args_and_kwargs({1: obj_3, 2: obj_2, 3: obj_1}, None)
+        initial_datetime_5 = Incrementer.get_datetime({1: obj_3, 2: obj_2, 3: obj_1})
         self.assertNotEqual(initial_datetime_1, initial_datetime_5)
 
     def test_list_of_cacheable_kwargs(self):
@@ -633,16 +634,16 @@ class CacheHelperCacheableTests(TestCase):
         obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
         obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
 
-        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=[obj_1, obj_2, obj_3])
-        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=[obj_3, obj_2, obj_1])
+        initial_datetime_1 = Incrementer.get_datetime(None, useless_kwarg=[obj_1, obj_2, obj_3])
+        initial_datetime_2 = Incrementer.get_datetime(None, useless_kwarg=[obj_3, obj_2, obj_1])
         self.assertEqual(initial_datetime_1, initial_datetime_2)
 
         # Test that order matters
-        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=[obj_2, obj_1, obj_3])
+        initial_datetime_3 = Incrementer.get_datetime(None, useless_kwarg=[obj_2, obj_1, obj_3])
         self.assertNotEqual(initial_datetime_1, initial_datetime_3)
 
         # Test that num elements matters
-        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=[obj_2, obj_1])
+        initial_datetime_4 = Incrementer.get_datetime(None, useless_kwarg=[obj_2, obj_1])
         self.assertNotEqual(initial_datetime_1, initial_datetime_4)
 
     def test_tuple_of_cacheable_kwargs(self):
@@ -653,17 +654,17 @@ class CacheHelperCacheableTests(TestCase):
         obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
         obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
 
-        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=(obj_1, obj_2, obj_3))
-        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=(obj_3, obj_2, obj_1))
+        initial_datetime_1 = Incrementer.get_datetime(None, useless_kwarg=(obj_1, obj_2, obj_3))
+        initial_datetime_2 = Incrementer.get_datetime(None, useless_kwarg=(obj_3, obj_2, obj_1))
         self.assertEqual(initial_datetime_1, initial_datetime_2)
         self.assertEqual(initial_datetime_1, initial_datetime_2)
 
         # Test that order matters
-        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=(obj_2, obj_1, obj_3))
+        initial_datetime_3 = Incrementer.get_datetime(None, useless_kwarg=(obj_2, obj_1, obj_3))
         self.assertNotEqual(initial_datetime_1, initial_datetime_3)
 
         # Test that num elements matters
-        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1=(obj_2, obj_1))
+        initial_datetime_4 = Incrementer.get_datetime(None, useless_kwarg=(obj_2, obj_1))
         self.assertNotEqual(initial_datetime_1, initial_datetime_4)
 
     def test_set_of_cacheable_kwargs(self):
@@ -674,17 +675,17 @@ class CacheHelperCacheableTests(TestCase):
         obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
         obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
 
-        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_1, obj_2})
-        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_2, obj_1})
-        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_2, obj_3})
-        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_3, obj_2})
+        initial_datetime_1 = Incrementer.get_datetime(None, useless_kwarg={obj_1, obj_2})
+        initial_datetime_2 = Incrementer.get_datetime(None, useless_kwarg={obj_2, obj_1})
+        initial_datetime_3 = Incrementer.get_datetime(None, useless_kwarg={obj_2, obj_3})
+        initial_datetime_4 = Incrementer.get_datetime(None, useless_kwarg={obj_3, obj_2})
 
         self.assertEqual(initial_datetime_1, initial_datetime_2)
         self.assertEqual(initial_datetime_1, initial_datetime_3)
         self.assertEqual(initial_datetime_1, initial_datetime_4)
 
         # Test that num elements matters
-        initial_datetime_5 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={obj_2, obj_1, obj_3})
+        initial_datetime_5 = Incrementer.get_datetime(None, useless_kwarg={obj_2, obj_1, obj_3})
         self.assertNotEqual(initial_datetime_1, initial_datetime_5)
 
     def test_dict_of_cacheable_kwargs(self):
@@ -695,21 +696,124 @@ class CacheHelperCacheableTests(TestCase):
         obj_2 = CacheableIfSumsAreEqual(1, 2)  # sum = 3
         obj_3 = CacheableIfSumsAreEqual(2, 2)  # sum = 4
 
-        initial_datetime_1 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={1: obj_1, 2: obj_2})
-        initial_datetime_2 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={2: obj_2, 1: obj_1})
-        initial_datetime_3 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={2: obj_2, 1: obj_3})
-        initial_datetime_4 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={1: obj_3, 2: obj_2})
+        initial_datetime_1 = Incrementer.get_datetime(None, useless_kwarg={1: obj_1, 2: obj_2})
+        initial_datetime_2 = Incrementer.get_datetime(None, useless_kwarg={2: obj_2, 1: obj_1})
+        initial_datetime_3 = Incrementer.get_datetime(None, useless_kwarg={2: obj_2, 1: obj_3})
+        initial_datetime_4 = Incrementer.get_datetime(None, useless_kwarg={1: obj_3, 2: obj_2})
 
         self.assertEqual(initial_datetime_1, initial_datetime_2)
         self.assertEqual(initial_datetime_1, initial_datetime_3)
         self.assertEqual(initial_datetime_1, initial_datetime_4)
 
         # Test that num elements matters
-        initial_datetime_5 = Incrementer.func_with_multiple_args_and_kwargs(None, None, kwarg_1={1: obj_3, 2: obj_2, 3: obj_1})
+        initial_datetime_5 = Incrementer.get_datetime(None, useless_kwarg={1: obj_3, 2: obj_2, 3: obj_1})
         self.assertNotEqual(initial_datetime_1, initial_datetime_5)
 
-    def test_max_depth(self):
-        pass
 
-    def test_complex_example(self):
-        pass
+class MaxDepthTests(TestCase):
+
+    @patch('cache_helper.settings.MAX_DEPTH', 2)
+    def test_max_depth_on_list_args_success(self):
+        """
+        Tests that a list arg with the max depth does not fail.
+        """
+        Incrementer.get_datetime([1, [2, 3]])
+        Incrementer.get_datetime([1, (2, 3)])
+        Incrementer.get_datetime([1, {2, 3}])
+        Incrementer.get_datetime([1, {2: 3}])
+        Incrementer.get_datetime([1, [2, 3], (2, 3), {2, 3}, {2: 3}])
+
+    @patch('cache_helper.settings.MAX_DEPTH', 2)
+    def test_max_depth_on_list_args_failure(self):
+        """
+        Tests that a list arg past the max depth fails.
+        """
+        with self.assertRaises(CacheKeyCreationError):
+            Incrementer.get_datetime([[1, [2, [3]]]])
+
+        with self.assertRaises(CacheKeyCreationError):
+            Incrementer.get_datetime([1, {2: [3, 4]}])
+
+        with self.assertRaises(CacheKeyCreationError):
+            Incrementer.get_datetime([1, {2: (3, 4)}])
+
+    @patch('cache_helper.settings.MAX_DEPTH', 2)
+    def test_max_depth_on_dict_args_success(self):
+        """
+        Tests that a dict arg with the max depth does not fail.
+        """
+        # Top level dict without errors
+        Incrementer.get_datetime({1: [2, 3]})
+        Incrementer.get_datetime({1: (2, 3)})
+        Incrementer.get_datetime({1: {2, 3}})
+        Incrementer.get_datetime({1: {2: 3}})
+        Incrementer.get_datetime({1: {2: 3}, 4: [5, 6], 7: {8, 9}, 10: (11, 12)})
+
+    @patch('cache_helper.settings.MAX_DEPTH', 2)
+    def test_max_depth_on_dict_args_failure(self):
+        """
+        Tests that a dict arg past the max depth fails.
+        """
+        with self.assertRaises(CacheKeyCreationError):
+            Incrementer.get_datetime({1: [{2: 3}]})
+
+        with self.assertRaises(CacheKeyCreationError):
+            Incrementer.get_datetime({1: {2: [3, 4]}})
+
+        with self.assertRaises(CacheKeyCreationError):
+            Incrementer.get_datetime({1: {2: {3: 4}}})
+
+    @patch('cache_helper.settings.MAX_DEPTH', 4)
+    def test_complex_object(self):
+        complex_obj = {
+            'depth_2': [
+                'depth_3',
+                {
+                    'depth_4': [None, CacheableIfSumsAreEqual(3, 5)]
+                },
+                CacheableIfSumsAreEqual(1, 3),
+            ],
+            'another': CacheableIfSumsAreEqual(4, 6),
+        }
+
+        equivalent_obj = {
+            'another': CacheableIfSumsAreEqual(10, 0),
+            'depth_2': [
+                'depth_3',
+                {
+                    'depth_4': [None, CacheableIfSumsAreEqual(8, 0)]
+                },
+                CacheableIfSumsAreEqual(4, 0),
+            ],
+        }
+
+        different_cacheable_obj = {
+            'depth_2': [
+                'depth_3',
+                {
+                    'depth_4': [None, CacheableIfSumsAreEqual(3, 5)]
+                },
+                CacheableIfSumsAreEqual(1, 3),
+            ],
+            'another': CacheableIfSumsAreEqual(2, 12),  # Sum does not equal 10
+        }
+
+        different_structure_obj = {
+            'depth_2': [
+                'depth_3',
+                CacheableIfSumsAreEqual(1, 3),
+                {
+                    'depth_4': [None, CacheableIfSumsAreEqual(3, 5)]
+                },
+            ],
+            'another': CacheableIfSumsAreEqual(4, 6),
+        }
+
+        complex_datetime = Incrementer.get_datetime(complex_obj)
+        equivalent_datetime = Incrementer.get_datetime(equivalent_obj)
+        different_cacheable_datetime = Incrementer.get_datetime(different_cacheable_obj)
+        different_structure_datetime = Incrementer.get_datetime(different_structure_obj)
+
+        self.assertEqual(complex_datetime, equivalent_datetime)
+        self.assertNotEqual(complex_datetime, different_cacheable_datetime)
+        self.assertNotEqual(complex_datetime, different_structure_datetime)


### PR DESCRIPTION
### Overview
* I found [this method](https://github.com/ycharts/ycharts/blob/develop/apps/model_portfolios/services/calc_data.py#L14) in the ycharts repo which tries to cache a dict of lists. 
  * Therefore we have a valid use case where the `CacheHelperCacheable` is nested at depth 2
  * I thought at this point, might as well implement the full DFS because it would look weird to hardcode a solution to depth 2
* I implemented a new DFS which I think is better for the following reasons:
  * Fixes a bug where the depth was being calculated incorrectly. e.g. `[(0,1), (0,1), (0,1), (0,1), (0,1)]` would be considered to be depth 5 instead of 2
  * Obviously biased here but IMO it's cleaner
* I also updated the minimum python version to 3.6 because I used f-strings without thinking... if we want to support older versions I can revert this

### New tests
* Testing when a `CacheHelperCacheable` is nested within an arg
* Testing when a `CacheHelperCacheable` is nested within a kwarg
* Testing that max depth works properly

### How to test
I was having issues with my `virtualenv`, I just quickly set up a new `venv` instead. Then:
- [ ] `python setup.py install`
- [ ] `cd test_project && python manage.py test test_project.tests`

