### PR TITLE
Add Exception Logging

### DIFF
--- a/cache_helper/__init__.py
+++ b/cache_helper/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 0, 3)
+VERSION = (1, 0, 4)

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -26,6 +26,10 @@ def cached(timeout):
             try:
                 value = cache.get(cache_key)
             except Exception:
+                logger.warning(
+                    f'Error retrieving value from Cache for Key: {function_cache_key}',
+                    exc_info=True,
+                )
                 value = None
 
             if value is None:
@@ -38,7 +42,7 @@ def cached(timeout):
 
                 except CacheSetError:
                     logger.warning(
-                        f'Error saving value to Cache for Key: {cache_key}',
+                        f'Error saving value to Cache for Key: {function_cache_key}',
                         exc_info=True,
                     )
 
@@ -77,6 +81,10 @@ def cached_class_method(timeout):
             try:
                 value = cache.get(cache_key)
             except Exception:
+                logger.warning(
+                    f'Error retrieving value from Cache for Key: {function_cache_key}',
+                    exc_info=True,
+                )
                 value = None
 
             if value is None:
@@ -88,7 +96,7 @@ def cached_class_method(timeout):
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     logger.warning(
-                        f'Error saving value to Cache for Key: {cache_key}',
+                        f'Error saving value to Cache for Key: {function_cache_key}',
                         exc_info=True,
                     )
 
@@ -141,10 +149,14 @@ def cached_instance_method(timeout):
             return fn
 
         def __call__(self, *args, **kwargs):
-            cache_key = self.create_cache_key(*args, **kwargs)
+            cache_key, function_cache_key = self.create_cache_key(*args, **kwargs)
             try:
                 value = cache.get(cache_key)
             except Exception:
+                logger.warning(
+                    f'Error retrieving value from Cache for Key: {function_cache_key}',
+                    exc_info=True,
+                )
                 value = None
             if value is None:
                 value = self.func(*args, **kwargs)
@@ -155,7 +167,7 @@ def cached_instance_method(timeout):
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     logger.warning(
-                        f'Error saving value to Cache for Key: {cache_key}',
+                        f'Error saving value to Cache for Key: {function_cache_key}',
                         exc_info=True,
                     )
             return value
@@ -168,7 +180,7 @@ def cached_instance_method(timeout):
             :param kwargs: The kwargs passed into the original function.
             :rtype: None
             """
-            cache_key = self.create_cache_key(*args, **kwargs)
+            cache_key, _ = self.create_cache_key(*args, **kwargs)
             cache.delete(cache_key)
 
         def create_cache_key(self, *args, **kwargs):
@@ -176,6 +188,6 @@ def cached_instance_method(timeout):
             func_name = utils.get_function_name(self.func)
             function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
-            return cache_key
+            return cache_key, function_cache_key
 
     return wrapper

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -1,3 +1,5 @@
+import logging
+
 try:
     from _pylibmc import Error as CacheSetError
 except ImportError:
@@ -10,6 +12,7 @@ from django.utils.functional import wraps
 
 from cache_helper import utils
 
+logger = logging.getLogger(__name__)
 
 def cached(timeout):
     def _cached(func):
@@ -34,7 +37,10 @@ def cached(timeout):
                     cache.set(cache_key, value, timeout)
 
                 except CacheSetError:
-                    pass
+                    logger.warning(
+                        f'Error saving value to Cache for Key: {cache_key}',
+                        exc_info=True,
+                    )
 
             return value
 
@@ -81,7 +87,10 @@ def cached_class_method(timeout):
                 try:
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
-                    pass
+                    logger.warning(
+                        f'Error saving value to Cache for Key: {cache_key}',
+                        exc_info=True,
+                    )
 
             return value
 
@@ -145,7 +154,10 @@ def cached_instance_method(timeout):
                 try:
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
-                    pass
+                    logger.warning(
+                        f'Error saving value to Cache for Key: {cache_key}',
+                        exc_info=True,
+                    )
             return value
 
         def _invalidate(self, *args, **kwargs):


### PR DESCRIPTION
### Overview
Adds some simple warning logs when exceptions are caught during the cache retrieval & setting process. These logs include the un-hashed cache key as well as the stacktrace of the error to help with debugging possible caching issues

### How to test
- [x] Running the following test cases should produce logs
```
CachedInstanceMethodTests.test_exception_during_cache_retrieval
CachedInstanceMethodTests.test_exception_during_cache_set
CachedClassMethodTests.test_exception_during_cache_retrieval
CachedClassMethodTests.test_exception_during_cache_set
CachedStaticMethodTests.test_exception_during_cache_retrieval
CachedStaticMethodTests.test_exception_during_cache_set
```
- [x] normal usage of the cache decorators (all other test cases) should not produce any logs