### PR TITLE
Fix Cache Misses None Values

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
         django-version: [ "4.2" ]
     steps:
       # Checks-out the  repository.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.7", "3.8", "3.9", "3.10" ]
-        django-version: [ "3.2" ]
+        django-version: [ "4.2" ]
     steps:
       # Checks-out the  repository.
       - uses: actions/checkout@v2

--- a/cache_helper/__init__.py
+++ b/cache_helper/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 0, 4)
+VERSION = (1, 0, 5)

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -26,6 +26,8 @@ def cached(timeout):
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
             try:
+                # Attempts to get cache key and defaults to a string constant which will be returned if the cache
+                # key does not exist due to expiry or never being set.
                 value = cache.get(cache_key, CACHE_KEY_NOT_FOUND)
             except Exception:
                 logger.warning(
@@ -80,6 +82,8 @@ def cached_class_method(timeout):
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
             try:
+                # Attempts to get cache key and defaults to a string constant which will be returned if the cache
+                # key does not exist due to expiry or never being set.
                 value = cache.get(cache_key, CACHE_KEY_NOT_FOUND)
             except Exception:
                 logger.warning(
@@ -151,7 +155,10 @@ def cached_instance_method(timeout):
 
         def __call__(self, *args, **kwargs):
             cache_key, function_cache_key = self.create_cache_key(*args, **kwargs)
+
             try:
+                # Attempts to get cache key and defaults to a string constant which will be returned if the cache
+                # key does not exist due to expiry or never being set.
                 value = cache.get(cache_key, CACHE_KEY_NOT_FOUND)
             except Exception:
                 logger.warning(

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -113,7 +113,7 @@ def cached_class_method(timeout):
             :param kwargs: The kwargs passed into the original function.
             :rtype: None
             """
-            function_cache_key = utils.get_function_cache_key(func_name, args[1:], kwargs)
+            function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
             cache.delete(cache_key)
 

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -76,9 +76,7 @@ def cached_class_method(timeout):
         @wraps(func)
         def wrapper(*args, **kwargs):
             # skip the first arg because it will be the class itself
-            function_cache_key = utils.get_function_cache_key(
-                func_name, args[1:], kwargs
-            )
+            function_cache_key = utils.get_function_cache_key(func_name, args[1:], kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
             try:
@@ -115,7 +113,7 @@ def cached_class_method(timeout):
             :param kwargs: The kwargs passed into the original function.
             :rtype: None
             """
-            function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
+            function_cache_key = utils.get_function_cache_key(func_name, args[1:], kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
             cache.delete(cache_key)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "a simple tool for making caching functions, methods, and class methods a little bit easier."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = [
     "cache",
     "django"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Used for Test Project
-Django>= 3.2, <4.0
+Django>= 4.2, <5.0
 
 # Used for tests coverage
 coverage


### PR DESCRIPTION
### Overview
- We currently have a bug in our caching repo where if the value we pull from our cache is None, we will always attempt to re evaluate the underlying function instead of just simply returning the None value in our cache.
- This is impacting certain tasks such as our category period fund flows, which makes intensive queries to our DB and was missing our cache for ~1300 funds.
- Fix this by separating out the case where we set a value to be None in the cache vs the django cache actually returning None due to an expired cache key or nonexistent cache key
- See relevant django cache docs here: https://docs.djangoproject.com/en/4.2/topics/cache/#django.core.cache.cache.get

### How to test
- [ ] I tested this locally by copying over this new `decorators.py` file to a docker container via the path `/usr/local/lib/python3.8/dist-packages/cache_helper/decorators.py` and then going into a django shell in that container and confirming this works as intended.
- [ ] Added tests for static, class, and instance cached method decorators to test None return. Tests will fail if you don't include changes made in `decorators.py` here.