### PR TITLE
use sentinels to check for cache key existance

### DIFF
--- a/cache_helper/__init__.py
+++ b/cache_helper/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 0, 5)
+VERSION = (1, 0, 6)

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -24,10 +24,10 @@ def cached(timeout):
             function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
+            # We need to determine whether the object exists in the cache, and since we may have stored a literal value
+            # None, use a sentinel object as the default
             sentinel = object()
             try:
-                # Attempts to get cache key and defaults to a string constant which will be returned if the cache
-                # key does not exist due to expiry or never being set.
                 value = cache.get(cache_key, sentinel)
             except Exception:
                 logger.warning(
@@ -79,10 +79,10 @@ def cached_class_method(timeout):
             function_cache_key = utils.get_function_cache_key(func_name, args[1:], kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
+            # We need to determine whether the object exists in the cache, and since we may have stored a literal value
+            # None, use a sentinel object as the default
             sentinel = object()
             try:
-                # Attempts to get cache key and defaults to a string constant which will be returned if the cache
-                # key does not exist due to expiry or never being set.
                 value = cache.get(cache_key, sentinel)
             except Exception:
                 logger.warning(
@@ -155,10 +155,10 @@ def cached_instance_method(timeout):
         def __call__(self, *args, **kwargs):
             cache_key, function_cache_key = self.create_cache_key(*args, **kwargs)
 
+            # We need to determine whether the object exists in the cache, and since we may have stored a literal value
+            # None, use a sentinel object as the default
             sentinel = object()
             try:
-                # Attempts to get cache key and defaults to a string constant which will be returned if the cache
-                # key does not exist due to expiry or never being set.
                 value = cache.get(cache_key, sentinel)
             except Exception:
                 logger.warning(

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -13,7 +13,6 @@ from django.utils.functional import wraps
 from cache_helper import utils
 
 logger = logging.getLogger(__name__)
-CACHE_KEY_NOT_FOUND = 'cache_key_not_found'
 
 
 def cached(timeout):
@@ -25,18 +24,19 @@ def cached(timeout):
             function_cache_key = utils.get_function_cache_key(func_name, args, kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
+            sentinel = object()
             try:
                 # Attempts to get cache key and defaults to a string constant which will be returned if the cache
                 # key does not exist due to expiry or never being set.
-                value = cache.get(cache_key, CACHE_KEY_NOT_FOUND)
+                value = cache.get(cache_key, sentinel)
             except Exception:
                 logger.warning(
                     f'Error retrieving value from Cache for Key: {function_cache_key}',
                     exc_info=True,
                 )
-                value = CACHE_KEY_NOT_FOUND
+                value = sentinel
 
-            if value == CACHE_KEY_NOT_FOUND:
+            if value is sentinel:
                 value = func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
@@ -79,18 +79,19 @@ def cached_class_method(timeout):
             function_cache_key = utils.get_function_cache_key(func_name, args[1:], kwargs)
             cache_key = utils.get_hashed_cache_key(function_cache_key)
 
+            sentinel = object()
             try:
                 # Attempts to get cache key and defaults to a string constant which will be returned if the cache
                 # key does not exist due to expiry or never being set.
-                value = cache.get(cache_key, CACHE_KEY_NOT_FOUND)
+                value = cache.get(cache_key, sentinel)
             except Exception:
                 logger.warning(
                     f'Error retrieving value from Cache for Key: {function_cache_key}',
                     exc_info=True,
                 )
-                value = CACHE_KEY_NOT_FOUND
+                value = sentinel
 
-            if value == CACHE_KEY_NOT_FOUND:
+            if value is sentinel:
                 value = func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
@@ -154,18 +155,19 @@ def cached_instance_method(timeout):
         def __call__(self, *args, **kwargs):
             cache_key, function_cache_key = self.create_cache_key(*args, **kwargs)
 
+            sentinel = object()
             try:
                 # Attempts to get cache key and defaults to a string constant which will be returned if the cache
                 # key does not exist due to expiry or never being set.
-                value = cache.get(cache_key, CACHE_KEY_NOT_FOUND)
+                value = cache.get(cache_key, sentinel)
             except Exception:
                 logger.warning(
                     f'Error retrieving value from Cache for Key: {function_cache_key}',
                     exc_info=True,
                 )
-                value = CACHE_KEY_NOT_FOUND
+                value = sentinel
 
-            if value == CACHE_KEY_NOT_FOUND:
+            if value is sentinel:
                 value = self.func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying


### PR DESCRIPTION
### Overview
- There was a bug introduced here when checking our cache value against a string literal, which breaks if the value is a pandas series.
- To handle this, use sentinels like Django recommends when pulling from the cache, see here: https://docs.djangoproject.com/en/4.2/topics/cache/#django.core.cache.cache.get

### How to test
- [ ] Make sure tests pass in ycharts repo once this is deloyed.