### PR TITLE
Add logging none cache value

### DIFF
--- a/cache_helper/__init__.py
+++ b/cache_helper/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 0, 6)
+VERSION = (1, 0, 7)

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -36,6 +36,8 @@ def cached(timeout):
                 )
                 value = sentinel
 
+            # If there is an issue with our cache client deserializing the value (due to memory or some other issue),
+            # we get a None response so log anytime this happens
             if value is None:
                 logger.warning(
                     'None cache value found for cache key: {}, function cache key: {}, value: {}'.format(
@@ -43,18 +45,12 @@ def cached(timeout):
                     )
                 )
 
-            # Need to check for None as well because the cache client sends a None response at times
             if value is sentinel or value is None:
                 value = func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
                 # cache system, handle it.
                 try:
-                    logger.info(
-                        'Setting cache key: {}, value: {} for function cache key: {}'.format(
-                            cache_key, value, function_cache_key
-                            )
-                        )
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     logger.warning(
@@ -104,6 +100,8 @@ def cached_class_method(timeout):
                 )
                 value = sentinel
 
+            # If there is an issue with our cache client deserializing the value (due to memory or some other issue),
+            # we get a None response so log anytime this happens
             if value is None:
                 logger.warning(
                     'None cache value found for cache key: {}, function cache key: {}, value: {}'.format(
@@ -111,18 +109,12 @@ def cached_class_method(timeout):
                     )
                 )
 
-            # Need to check for None as well because the cache client sends a None response at times
             if value is sentinel or value is None:
                 value = func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
                 # cache system, handle it.
                 try:
-                    logger.info(
-                        'Setting cache key: {}, value: {} for function cache key: {}'.format(
-                            cache_key, value, function_cache_key
-                            )
-                        )
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     logger.warning(
@@ -193,6 +185,8 @@ def cached_instance_method(timeout):
                 )
                 value = sentinel
 
+            # If there is an issue with our cache client deserializing the value (due to memory or some other issue),
+            # we get a None response so log anytime this happens
             if value is None:
                 logger.warning(
                     'None cache value found for cache key: {}, function cache key: {}, value: {}'.format(
@@ -200,18 +194,12 @@ def cached_instance_method(timeout):
                     )
                 )
 
-            # Need to check for None as well because the cache client sends a None response at times
             if value is sentinel or value is None:
                 value = self.func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
                 # cache system, handle it.
                 try:
-                    logger.info(
-                        'Setting cache key: {}, value: {} for function cache key: {}'.format(
-                            cache_key, value, function_cache_key
-                            )
-                        )
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     logger.warning(

--- a/cache_helper/decorators.py
+++ b/cache_helper/decorators.py
@@ -36,12 +36,25 @@ def cached(timeout):
                 )
                 value = sentinel
 
-            if value is sentinel:
+            if value is None:
+                logger.warning(
+                    'None cache value found for cache key: {}, function cache key: {}, value: {}'.format(
+                        cache_key, function_cache_key, value
+                    )
+                )
+
+            # Need to check for None as well because the cache client sends a None response at times
+            if value is sentinel or value is None:
                 value = func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
                 # cache system, handle it.
                 try:
+                    logger.info(
+                        'Setting cache key: {}, value: {} for function cache key: {}'.format(
+                            cache_key, value, function_cache_key
+                            )
+                        )
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     logger.warning(
@@ -91,12 +104,25 @@ def cached_class_method(timeout):
                 )
                 value = sentinel
 
-            if value is sentinel:
+            if value is None:
+                logger.warning(
+                    'None cache value found for cache key: {}, function cache key: {}, value: {}'.format(
+                        cache_key, function_cache_key, value
+                    )
+                )
+
+            # Need to check for None as well because the cache client sends a None response at times
+            if value is sentinel or value is None:
                 value = func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
                 # cache system, handle it.
                 try:
+                    logger.info(
+                        'Setting cache key: {}, value: {} for function cache key: {}'.format(
+                            cache_key, value, function_cache_key
+                            )
+                        )
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     logger.warning(
@@ -167,12 +193,25 @@ def cached_instance_method(timeout):
                 )
                 value = sentinel
 
-            if value is sentinel:
+            if value is None:
+                logger.warning(
+                    'None cache value found for cache key: {}, function cache key: {}, value: {}'.format(
+                        cache_key, function_cache_key, value
+                    )
+                )
+
+            # Need to check for None as well because the cache client sends a None response at times
+            if value is sentinel or value is None:
                 value = self.func(*args, **kwargs)
                 # Try and set the key, value pair in the cache.
                 # But if it fails on an error from the underlying
                 # cache system, handle it.
                 try:
+                    logger.info(
+                        'Setting cache key: {}, value: {} for function cache key: {}'.format(
+                            cache_key, value, function_cache_key
+                            )
+                        )
                     cache.set(cache_key, value, timeout)
                 except CacheSetError:
                     logger.warning(

--- a/test_project/test_project/tests.py
+++ b/test_project/test_project/tests.py
@@ -41,25 +41,6 @@ class Incrementer:
     ):
         return datetime.utcnow()
 
-    @cached_instance_method(60 * 60)
-    def instance_increment_by_none_return(self, num):
-        self.instance_counter += num
-        return None
-
-    @classmethod
-    @cached_class_method(60 * 60)
-    def class_increment_by_none_return(cls, num):
-        cls.class_counter += num
-        return None
-
-    @staticmethod
-    @cached(60 * 60)
-    def static_increment_by_none_return(num):
-        global GLOBAL_COUNTER
-        GLOBAL_COUNTER += num
-
-        return None
-
 
 class SubclassIncrementer(Incrementer):
     class_counter = 500
@@ -289,26 +270,6 @@ class CachedInstanceMethodTests(TestCase):
         # but 2 is still stale
         self.assertEqual(incrementer.instance_increment_by(2), 103)
 
-    def test_cached_instance_method_none_return(self):
-        """
-        Tests that calling a cached instance method returning None still uses the cache as expected.
-        """
-        incrementer = Incrementer(100)
-
-        # Hasn't been computed before, so the function actually gets called
-        incrementer.instance_increment_by_none_return(1)
-        self.assertEqual(incrementer.instance_counter, 101)
-
-        incrementer.instance_increment_by_none_return(2)
-        self.assertEqual(incrementer.instance_counter, 103)
-
-        # We expect the instance counter to stay the same as the last time it was updated and not increment again
-        incrementer.instance_increment_by_none_return(1)
-        self.assertEqual(incrementer.instance_counter, 103)
-
-        incrementer.instance_increment_by_none_return(2)
-        self.assertEqual(incrementer.instance_counter, 103)
-
 
 class CachedClassMethodTests(TestCase):
     def tearDown(self):
@@ -451,24 +412,6 @@ class CachedClassMethodTests(TestCase):
         # but 2 is still stale
         self.assertEqual(Incrementer.class_increment_by(2), 503)
 
-    def test_cached_class_method_none_return(self):
-        """
-        Tests that calling a cached class method returning None still uses the cache as expected.
-        """
-        # Hasn't been computed before, so the function actually gets called
-        Incrementer.class_increment_by_none_return(1)
-        self.assertEqual(Incrementer.class_counter, 501)
-
-        Incrementer.class_increment_by_none_return(2)
-        self.assertEqual(Incrementer.class_counter, 503)
-
-        # We expect the class counter to stay the same as the last time it was updated and not increment again
-        Incrementer.class_increment_by_none_return(1)
-        self.assertEqual(Incrementer.class_counter, 503)
-
-        Incrementer.class_increment_by_none_return(2)
-        self.assertEqual(Incrementer.class_counter, 503)
-
 
 class CachedStaticMethodTests(TestCase):
     def tearDown(self):
@@ -610,24 +553,6 @@ class CachedStaticMethodTests(TestCase):
 
         # but 2 is still stale
         self.assertEqual(Incrementer.get_datetime(2), initial_datetime_2)
-
-    def test_cached_class_method_none_return(self):
-        """
-        Tests that calling a cached static method returning None still uses the cache as expected.
-        """
-        # Hasn't been computed before, so the function actually gets called
-        Incrementer.static_increment_by_none_return(1)
-        self.assertEqual(GLOBAL_COUNTER, 201)
-
-        Incrementer.static_increment_by_none_return(2)
-        self.assertEqual(GLOBAL_COUNTER, 203)
-
-        # We expect the global counter to stay the same as the last time it was updated and not increment again
-        Incrementer.static_increment_by_none_return(1)
-        self.assertEqual(GLOBAL_COUNTER, 203)
-
-        Incrementer.static_increment_by_none_return(2)
-        self.assertEqual(GLOBAL_COUNTER, 203)
 
 
 class CacheHelperCacheableTests(TestCase):


### PR DESCRIPTION
### Overview
- There are times where our cache client returns a None value when the cache key actually does exist with a non `None` value.
- Add logging to see all the cache keys that return `None` when getting the key and also log every time we set a cache key to confirm the key has been properly set.